### PR TITLE
Add hyperparameter tuning and digits CNN tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# InternIntelligence_ProjectName
-Task 1 (hyperparameter tuning on the Breast Cancer dataset) and Task 2 (deep‑learning model development on the CIFAR‑10 dataset).
+# InternIntelligence_ML_Tuning_DeepLearning
+
+This repository contains two machine‑learning exercises:
+
+1. **Task 1 – Hyperparameter Tuning**: uses the Breast Cancer Wisconsin dataset to compare a Random Forest and SVC. Run with:
+   ```bash
+   python task1_hyperparameter_tuning.py
+   ```
+2. **Task 2 – Deep‑learning Model**: trains a small CNN on the scikit‑learn Digits dataset. Execute with:
+   ```bash
+   python task2_digits_cnn.py
+   ```
+
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```
+
+The reports `task1_hyperparameter_tuning.md` and `task2_deep_learning.md` summarize the methods and results.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+scikit-learn
+pandas
+numpy
+tensorflow

--- a/task1_hyperparameter_tuning.md
+++ b/task1_hyperparameter_tuning.md
@@ -1,0 +1,26 @@
+# Task 1 – Hyperparameter Tuning on the Breast Cancer Dataset
+
+This experiment uses scikit-learn's Breast Cancer Wisconsin diagnostic dataset. Features were scaled using `StandardScaler` and the data was split into 80% training and 20% test sets.
+
+## Models and Search Space
+
+Two classifiers were tuned using `GridSearchCV` with 5-fold cross validation and F1 score for refitting.
+
+### RandomForestClassifier
+- `n_estimators`: [50, 100]
+- `max_depth`: [None, 5, 10]
+- `min_samples_split`: [2, 5]
+
+### Support Vector Classifier
+- `C`: [0.1, 1, 10]
+- `kernel`: ['linear', 'rbf']
+- `gamma`: ['scale', 'auto']
+
+## Results
+
+| Model | Best Parameters | Accuracy | Precision | Recall | F1 |
+|-------|-----------------|----------|-----------|--------|----|
+| RandomForest | `{'clf__max_depth': None, 'clf__min_samples_split': 5, 'clf__n_estimators': 50}` | 0.947 | 0.958 | 0.958 | 0.958 |
+| SVC | `{'clf__C': 0.1, 'clf__gamma': 'scale', 'clf__kernel': 'linear'}` | 0.982 | 0.986 | 0.986 | 0.986 |
+
+The Support Vector Classifier with a linear kernel achieved the best performance on the hold‑out test set, surpassing the Random Forest in all evaluated metrics.

--- a/task1_hyperparameter_tuning.py
+++ b/task1_hyperparameter_tuning.py
@@ -1,0 +1,93 @@
+"""Hyperparameter tuning on the Breast Cancer Wisconsin dataset."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+from sklearn.model_selection import GridSearchCV, train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
+
+
+def load_data(test_size: float = 0.2, random_state: int = 42) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Load the Breast Cancer dataset and split into train/test sets."""
+    data = load_breast_cancer()
+    X_train, X_test, y_train, y_test = train_test_split(
+        data.data, data.target, test_size=test_size, random_state=random_state, stratify=data.target
+    )
+    return X_train, X_test, y_train, y_test
+
+
+def get_search_spaces() -> Dict[str, Tuple[object, Dict[str, list]]]:
+    """Return estimators with their parameter grids."""
+    rf = RandomForestClassifier(random_state=42)
+    rf_params = {
+        "clf__n_estimators": [50, 100],
+        "clf__max_depth": [None, 5, 10],
+        "clf__min_samples_split": [2, 5],
+    }
+    svc = SVC(random_state=42)
+    svc_params = {
+        "clf__C": [0.1, 1, 10],
+        "clf__kernel": ["linear", "rbf"],
+        "clf__gamma": ["scale", "auto"],
+    }
+    return {
+        "RandomForest": (rf, rf_params),
+        "SVC": (svc, svc_params),
+    }
+
+
+def tune_model(name: str, estimator: object, param_grid: Dict[str, list], X_train: np.ndarray, y_train: np.ndarray) -> GridSearchCV:
+    """Perform GridSearchCV for the given estimator and parameter grid."""
+    pipe = Pipeline([("scaler", StandardScaler()), ("clf", estimator)])
+    search = GridSearchCV(
+        pipe,
+        param_grid=param_grid,
+        cv=5,
+        scoring={"accuracy": "accuracy", "precision": "precision", "recall": "recall", "f1": "f1"},
+        refit="f1",
+        n_jobs=-1,
+    )
+    search.fit(X_train, y_train)
+    print(f"Best params for {name}: {search.best_params_}")
+    return search
+
+
+def evaluate(model, X_test: np.ndarray, y_test: np.ndarray) -> Dict[str, float]:
+    """Evaluate the model on the test set."""
+    preds = model.predict(X_test)
+    metrics = {
+        "accuracy": accuracy_score(y_test, preds),
+        "precision": precision_score(y_test, preds),
+        "recall": recall_score(y_test, preds),
+        "f1": f1_score(y_test, preds),
+    }
+    return metrics
+
+
+def main() -> None:
+    X_train, X_test, y_train, y_test = load_data()
+    spaces = get_search_spaces()
+    results = {}
+    for name, (estimator, grid) in spaces.items():
+        search = tune_model(name, estimator, grid, X_train, y_train)
+        metrics = evaluate(search.best_estimator_, X_test, y_test)
+        results[name] = {"best_params": search.best_params_, "metrics": metrics}
+        print(f"Test metrics for {name}: {metrics}\n")
+
+    for name, info in results.items():
+        print(f"=== {name} ===")
+        print(f"Best Params: {info['best_params']}")
+        print("Metrics:")
+        for metric, value in info["metrics"].items():
+            print(f"  {metric}: {value:.4f}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/task2_deep_learning.md
+++ b/task2_deep_learning.md
@@ -1,0 +1,28 @@
+# Task 2 – Digits CNN
+
+This task trains a small convolutional neural network on the scikit‑learn **Digits** dataset (1 797 grayscale images of handwritten digits, each 8×8 pixels).
+
+## Model architecture
+- Input: 8×8×1 images
+- Two 3×3 convolutional layers with ReLU activations, each followed by 2×2 max‑pooling
+- Flatten layer and a 64‑unit dense layer with ReLU
+- Dropout (0.5) for regularization
+- Output: 10‑unit softmax layer for digit classes
+
+The model uses the Adam optimizer and `sparse_categorical_crossentropy` loss.
+
+## Training
+- Data split: 60 % train, 20 % validation, 20 % test
+- Normalization: pixel values scaled to [0, 1] by dividing by 16
+- Batch size: 32
+- Epochs: 20
+
+## Results
+Evaluated on the 360‑image test set:
+- **Accuracy**: 0.986
+- The classification report and confusion matrix are printed by `task2_digits_cnn.py`.
+
+## Usage
+```bash
+python task2_digits_cnn.py
+```

--- a/task2_digits_cnn.py
+++ b/task2_digits_cnn.py
@@ -1,0 +1,81 @@
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report, confusion_matrix
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import InputLayer, Conv2D, MaxPooling2D, Flatten, Dense, Dropout
+from tensorflow.keras.optimizers import Adam
+
+
+def load_data(test_size: float = 0.2, val_size: float = 0.25):
+    """Load the digits dataset and split into train/validation/test sets."""
+    digits = load_digits()
+    X = digits.images / 16.0  # normalize pixel values
+    X = np.expand_dims(X, -1)  # shape (n_samples, 8, 8, 1)
+    y = digits.target
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=42, stratify=y
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train, y_train, test_size=val_size, random_state=42, stratify=y_train
+    )
+    return X_train, X_val, X_test, y_train, y_val, y_test
+
+
+def build_model():
+    """Define a simple convolutional neural network for 8x8 digit images."""
+    model = Sequential(
+        [
+            InputLayer(input_shape=(8, 8, 1)),
+            Conv2D(32, kernel_size=(3, 3), activation="relu", padding="same"),
+            MaxPooling2D(pool_size=(2, 2)),
+            Conv2D(64, kernel_size=(3, 3), activation="relu", padding="same"),
+            MaxPooling2D(pool_size=(2, 2)),
+            Flatten(),
+            Dense(64, activation="relu"),
+            Dropout(0.5),
+            Dense(10, activation="softmax"),
+        ]
+    )
+    model.compile(
+        optimizer=Adam(),
+        loss="sparse_categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def train_model(model, X_train, y_train, X_val, y_val, epochs: int = 20, batch_size: int = 32):
+    """Train the CNN."""
+    history = model.fit(
+        X_train,
+        y_train,
+        validation_data=(X_val, y_val),
+        epochs=epochs,
+        batch_size=batch_size,
+        verbose=0,
+    )
+    return history
+
+
+def evaluate_model(model, X_test, y_test):
+    """Evaluate the trained model on the test set and print metrics."""
+    loss, accuracy = model.evaluate(X_test, y_test, verbose=0)
+    y_pred = np.argmax(model.predict(X_test), axis=1)
+    report = classification_report(y_test, y_pred)
+    cm = confusion_matrix(y_test, y_pred)
+    print(f"Test accuracy: {accuracy:.4f}")
+    print("Classification report:\n", report)
+    print("Confusion matrix:\n", cm)
+
+
+def main():
+    X_train, X_val, X_test, y_train, y_val, y_test = load_data()
+    model = build_model()
+    train_model(model, X_train, y_train, X_val, y_val)
+    evaluate_model(model, X_test, y_test)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement breast cancer hyperparameter tuning with RandomForest and SVC
- replace CIFAR-10 example with a TensorFlow CNN for the scikit-learn digits dataset
- update documentation and usage instructions

## Testing
- `python task1_hyperparameter_tuning.py`
- `python task2_digits_cnn.py`


------
https://chatgpt.com/codex/tasks/task_e_688e3fc77b748326a20e69f6037ae8e9