### PR TITLE
Add tests and CI workflow for ML tasks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/test_task1.py
+++ b/tests/test_task1.py
@@ -1,0 +1,15 @@
+import pathlib
+import re
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import task1_hyperparameter_tuning as t
+
+
+def test_task1_f1_exceeds_threshold(capsys):
+    t.main()
+    captured = capsys.readouterr().out
+    f1_scores = [float(match) for match in re.findall(r"f1: ([0-9.]+)", captured)]
+    assert f1_scores, "No F1 scores found in output"
+    assert max(f1_scores) > 0.95

--- a/tests/test_task2.py
+++ b/tests/test_task2.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+import numpy as np
+import tensorflow as tf
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import task2_digits_cnn as t
+
+
+def test_task2_accuracy_above_threshold():
+    np.random.seed(42)
+    tf.random.set_seed(42)
+    X_train, X_val, X_test, y_train, y_val, y_test = t.load_data()
+    model = t.build_model()
+    t.train_model(model, X_train, y_train, X_val, y_val, epochs=20)
+    loss, acc = model.evaluate(X_test, y_test, verbose=0)
+    assert acc > 0.97


### PR DESCRIPTION
## Summary
- add unit tests validating F1 score for hyperparameter tuning and accuracy for CNN
- configure GitHub Actions workflow to run pytest on pushes and pull requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f2885c92c8326acb9705f3151dc8a